### PR TITLE
2019 changelog merge into development branch

### DIFF
--- a/package.json
+++ b/package.json
@@ -115,7 +115,9 @@
     },
     "dependencies": {
         "@types/rimraf": "^2.0.2",
-        "rimraf": "^2.0.2"
+        "@types/semver": "^6.0.1",
+        "rimraf": "^2.0.2",
+        "semver": "^6.1.2"
     },
     "extensionDependencies": [
         "wpilibsuite.vscode-wpilib"

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
         "onCommand:extension.forceCompliance",
         "onCommand:extension.changeComplianceTestPref",
         "onCommand:extension.toggleChangelog",
-        "onCommand:extension.showChangelog"
+        "onCommand:extension.showChangelog",
+        "onCommand:extension.resetAutoShowChangelog"
     ],
     "main": "./dist/extension",
     "contributes": {
@@ -46,6 +47,10 @@
             {
                 "command": "extension.toggleChangelog",
                 "title": "Kotlin-FRC: Toggle Auto-Show Changelog"
+            },
+            {
+                "command": "extension.resetAutoShowChangelog",
+                "title": "Kotlin-FRC: Reset Auto-Show Changelog"
             }
         ],
         "menus": {
@@ -78,6 +83,9 @@
                 },
                 {
                     "command": "extension.toggleChangelog"
+                },
+                {
+                    "command": "extension.resetAutoShowChangelog"
                 }
             ]
         }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,9 @@
         "onCommand:extension.createNew",
         "onCommand:extension.convertJavaProject",
         "onCommand:extension.forceCompliance",
-        "onCommand:extension.changeComplianceTestPref"
+        "onCommand:extension.changeComplianceTestPref",
+        "onCommand:extension.toggleChangelog",
+        "onCommand:extension.showChangelog"
     ],
     "main": "./dist/extension",
     "contributes": {
@@ -36,6 +38,14 @@
             {
                 "command": "extension.changeComplianceTestPref",
                 "title": "Kotlin-FRC: Change GradleRio Checks"
+            },
+            {
+                "command": "extension.showChangelog",
+                "title": "Kotlin-FRC: Show Changelog"
+            },
+            {
+                "command": "extension.toggleChangelog",
+                "title": "Kotlin-FRC: Toggle Auto-Show Changelog"
             }
         ],
         "menus": {
@@ -62,6 +72,12 @@
                 {
                     "command": "extension.changeComplianceTestPref",
                     "when": "isWPILibProject"
+                },
+                {
+                    "command": "extension.showChangelog"
+                },
+                {
+                    "command": "extension.toggleChangelog"
                 }
             ]
         }

--- a/src/changelog.ts
+++ b/src/changelog.ts
@@ -1,0 +1,57 @@
+import * as vscode from 'vscode';
+import * as semver from 'semver';
+
+export function displayChangelog(context: vscode.ExtensionContext) {
+	if (extensionWasUpdated(context)) {
+		showChangelog();
+	}
+}
+
+function extensionWasUpdated(context: vscode.ExtensionContext): boolean {
+	let thisExtension = vscode.extensions.getExtension('brenek.kotlin-for-frc');
+	if (thisExtension === undefined) {
+		console.log("thisExtension was undefined, the changelog will not be displayed.");
+		return false;
+	}
+	let currentVersion = thisExtension.packageJSON["version"];
+	let storedVersion = context.globalState.get("lastInitVersion", "0.0.0");
+
+	context.globalState.update("lastInitVersion", "0.0.0");
+
+	// @ts-ignore Note: This shouldn't be needed because true is a default value but it's here anyways
+	if (context.globalState.get("toggleChangelog", true) === false) {
+		return false;
+	}
+
+	if (semver.satisfies(currentVersion, `>${storedVersion}`)) {
+		return true;
+	} else {
+		return false;
+	}
+}
+
+export function showChangelog() {
+	const panel = vscode.window.createWebviewPanel('kotlin-for-frcChangelog', 'Kotlin For FRC Changelog', vscode.ViewColumn.One, {});
+
+	panel.webview.html = getWebviewContent();
+}
+
+function getWebviewContent() {
+	// Webview body content is generated using the batch file in the main directory.
+	// Only copy the latest release and add any special notes you want to send the end user.
+	return `<!DOCTYPE html>
+<html lang="en">
+<head>
+	<meta charset="UTF-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<title>Kotlin For FRC Changelog</title>
+</head>
+<body>
+	<h1>Change Log</h1>
+	<h2>1.4.0</h2>
+	<ul>
+		<li>Faster extension loading times using webpack</li>
+	</ul>
+</body>
+</html>`;
+}

--- a/src/changelog.ts
+++ b/src/changelog.ts
@@ -16,7 +16,7 @@ function extensionWasUpdated(context: vscode.ExtensionContext): boolean {
 	let currentVersion = thisExtension.packageJSON["version"];
 	let storedVersion = context.globalState.get("lastInitVersion", "0.0.0");
 
-	context.globalState.update("lastInitVersion", "0.0.0");
+	context.globalState.update("lastInitVersion", currentVersion);
 
 	// @ts-ignore Note: This shouldn't be needed because true is a default value but it's here anyways
 	if (context.globalState.get("toggleChangelog", true) === false) {

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -7,6 +7,7 @@ import * as rimraf from "rimraf";
 import * as fs from "fs";
 import { setRunComplianceTests } from "./preferences";
 import * as kotlinExt from "./extension";
+import * as chnglog from "./changelog";
 
 export function createNew(file_path: any) {
 	vscode.window.showQuickPick(["Command", "Subsystem", "Trigger", "Empty Class"]).then((option: any) => {
@@ -229,4 +230,17 @@ export function createMainKt() {
 
 export function createBuildGradle() {
 	filegenerator.createFileWithContent("build.gradle", templateinterpreter.getParsedGradle());
+}
+
+export function showChangelog() { chnglog.showChangelog(); }
+
+export function toggleChangelog(context: vscode.ExtensionContext) {
+	var currentValue = context.globalState.get("toggleChangelog", true);
+	if (currentValue === true) {
+		context.globalState.update("toggleChangelog", false);
+		vscode.window.showInformationMessage("Kotlin for FRC: Turned auto-show changelog off.");
+	} else {
+		context.globalState.update("toggleChangelog", true);
+		vscode.window.showInformationMessage("Kotlin for FRC: Turned auto-show changelog on.");
+	}
 }

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -244,3 +244,8 @@ export function toggleChangelog(context: vscode.ExtensionContext) {
 		vscode.window.showInformationMessage("Kotlin for FRC: Turned auto-show changelog on.");
 	}
 }
+
+export function resetAutoShowChangelog(context: vscode.ExtensionContext ) {
+	context.globalState.update("lastInitVersion", "0.0.0");
+	vscode.window.showInformationMessage("Kotlin for FRC: Auto-Show changelog reset.");
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,46 +1,47 @@
-'use strict';
-import * as vscode from 'vscode';
+"use strict";
+import * as vscode from "vscode";
 import * as commands from "./commands";
 import * as fs from "fs";
 import * as preferences from "./preferences";
 import * as compliance from "./compliance";
-import { robotType } from './template_interpreter';
+import { robotType } from "./template_interpreter";
+import { displayChangelog } from "./changelog";
 
 var currentWorkspacePath: string;
 var currentWorkspaceFsPath: string;
 
 export function activate(context: vscode.ExtensionContext) {
 
-    console.log('Congratulations, your extension "kotlin-for-frc" is now active!');
+    console.log("Congratulations, your extension \"kotlin-for-frc\" is now active!");
 
     // Setting up current workspace
     resetWorkspaceFolderPaths();
 
     // * Registering commands
     console.log("Registering commands");
-    let disposable = vscode.commands.registerCommand('extension.createNew', (file_path: any) => {
+    let disposable = vscode.commands.registerCommand("extension.createNew", (file_path: any) => {
         commands.createNew(file_path);
     });
 
     context.subscriptions.push(disposable);
 
-    disposable = vscode.commands.registerCommand('extension.forceCompliance', (file_path: any) => {
+    disposable = vscode.commands.registerCommand("extension.forceCompliance", (file_path: any) => {
         commands.forceCompliance();
     });
 
     context.subscriptions.push(disposable);
 
-    disposable = vscode.commands.registerCommand('extension.changeComplianceTestPref', (file_path: any) => {
+    disposable = vscode.commands.registerCommand("extension.changeComplianceTestPref", (file_path: any) => {
         commands.changeComplianceTestPref();
     });
 
     context.subscriptions.push(disposable);
 
-    disposable = vscode.commands.registerCommand('extension.convertJavaProject', () => {
+    disposable = vscode.commands.registerCommand("extension.convertJavaProject", () => {
         console.log("Reading Robot.java");
         // Check to make sure file paths are even there
         try {
-            var robot_java: string = fs.readFileSync(currentWorkspaceFsPath + "/src/main/java/frc/robot/Robot.java", 'utf8');
+            var robot_java: string = fs.readFileSync(currentWorkspaceFsPath + "/src/main/java/frc/robot/Robot.java", "utf8");
         }
         catch (e) {
             console.log(e);
@@ -77,17 +78,24 @@ export function activate(context: vscode.ExtensionContext) {
     
     context.subscriptions.push(disposable);
 
-    disposable = vscode.commands.registerCommand('extension.showChangelog', (file_path: any) => {
+    disposable = vscode.commands.registerCommand("extension.showChangelog", (file_path: any) => {
         commands.showChangelog();
     });
 
     context.subscriptions.push(disposable);
 
-    disposable = vscode.commands.registerCommand('extension.toggleChangelog', (file_path: any) => {
+    disposable = vscode.commands.registerCommand("extension.toggleChangelog", (file_path: any) => {
         commands.toggleChangelog(context);
     });
 
     context.subscriptions.push(disposable);
+
+    disposable = vscode.commands.registerCommand("extension.resetAutoShowChangelog", (file_path: any) => {
+        commands.resetAutoShowChangelog(context);
+    });
+
+    context.subscriptions.push(disposable);
+
     // * End registering commands
 
     // * Compliance testing
@@ -102,6 +110,9 @@ export function activate(context: vscode.ExtensionContext) {
             compliance.makeMainKtCompliant();
         }
     }
+
+    // * Check if the extension was updated and display the changelog if it was
+    displayChangelog(context);
 }
 
 // this method is called when your extension is deactivated
@@ -130,7 +141,7 @@ export function setWorkspaceFolderPathsFromUri(uri: vscode.Uri) {
 }
 
 export function resetWorkspaceFolderPaths() {
-    if (typeof vscode.workspace.workspaceFolders === 'undefined') {
+    if (typeof vscode.workspace.workspaceFolders === "undefined") {
         console.log("Not a valid workspace");
         vscode.window.showErrorMessage("Kotlin for FRC: Not a workspace!");
         return;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -76,6 +76,18 @@ export function activate(context: vscode.ExtensionContext) {
     });
     
     context.subscriptions.push(disposable);
+
+    disposable = vscode.commands.registerCommand('extension.showChangelog', (file_path: any) => {
+        commands.showChangelog();
+    });
+
+    context.subscriptions.push(disposable);
+
+    disposable = vscode.commands.registerCommand('extension.toggleChangelog', (file_path: any) => {
+        commands.toggleChangelog(context);
+    });
+
+    context.subscriptions.push(disposable);
     // * End registering commands
 
     // * Compliance testing


### PR DESCRIPTION
2019-changelog implements the changelog feature with the current 2019 Kotlin For FRC extension. Eventually, the original implementation will be merged in when the 2020 branch is merged.