### PR TITLE
Simulation config

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,13 @@
                     "type": "boolean",
                     "default": true,
                     "scope": "application",
-                    "description": "Whether or not to show the changelog when Kotlin for FRC has been updated"
+                    "description": "Whether or not to show the changelog when Kotlin for FRC has been updated."
+                },
+                "kotlinForFRC.simulate.javaHome": {
+                    "type": "string",
+                    "default": null,
+                    "scope": "window",
+                    "description": "Defines a custom JAVA_HOME for Kotlin for FRC to use when simulating FRC Kotlin code."
                 }
             }
         },

--- a/src/util/gradle.ts
+++ b/src/util/gradle.ts
@@ -9,9 +9,17 @@ export function getPlatformGradlew(): string {
 }
 
 export function getJavaHomeGradleArg(): string {
-    let javaHomeConfig = vscode.workspace.getConfiguration("java").get("home");
-    if (javaHomeConfig === null || javaHomeConfig === undefined) {
+    let javaHomeConfig = vscode.workspace.getConfiguration("java").get<string | undefined | null>("home");
+    let kffJavaHomeConfig = vscode.workspace.getConfiguration("kotlinForFRC.simulate").get<string | undefined | null>("javaHome");
+    if ((kffJavaHomeConfig === null || kffJavaHomeConfig === undefined) && (javaHomeConfig === null || javaHomeConfig === undefined)) {
         return "";
     }
-    return `-Dorg.gradle.java.home="${javaHomeConfig}"`;
+    let javaHome = "";
+    if (kffJavaHomeConfig !== null && kffJavaHomeConfig !== undefined) {
+        javaHome = kffJavaHomeConfig;
+    } else if (javaHomeConfig !== null && javaHomeConfig !== undefined) {
+        // Should just be an else but typescript doesn't realize that the above return statement exists to check null/undefined
+        javaHome = javaHomeConfig;
+    }
+    return `-Dorg.gradle.java.home="${javaHome}"`;
 }


### PR DESCRIPTION
Adds the `kotlinForFRC.simulate.javaHome` VSCode configuration point for specifying a java home to simulate FRC Kotlin code with.